### PR TITLE
Adds Repository layer to encapsulate Service and authentication calls

### DIFF
--- a/mood-reading-machines.xcodeproj/project.pbxproj
+++ b/mood-reading-machines.xcodeproj/project.pbxproj
@@ -17,6 +17,12 @@
 		6B6F5E8321444D230072E180 /* TwitterMoyaRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6F5E8221444D230072E180 /* TwitterMoyaRouter.swift */; };
 		6B6F5E85214453D80072E180 /* TwitterAccessToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6F5E84214453D80072E180 /* TwitterAccessToken.swift */; };
 		6B6F5E8A2144784F0072E180 /* KeychainStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6F5E892144784F0072E180 /* KeychainStorageTests.swift */; };
+		6B6F5E8C2144811B0072E180 /* TwitterRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6F5E8B2144811B0072E180 /* TwitterRepository.swift */; };
+		6B6F5E8E2144812E0072E180 /* APITwitterRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6F5E8D2144812E0072E180 /* APITwitterRepository.swift */; };
+		6B6F5E91214484590072E180 /* MockTwitterService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6F5E90214484590072E180 /* MockTwitterService.swift */; };
+		6B6F5E94214484DC0072E180 /* DataMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6F5E93214484DC0072E180 /* DataMock.swift */; };
+		6B6F5E97214485FA0072E180 /* APITwitterRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6F5E96214485FA0072E180 /* APITwitterRepositoryTests.swift */; };
+		6B6F5E992144866F0072E180 /* MockLocalStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6F5E982144866F0072E180 /* MockLocalStorage.swift */; };
 		6B75B0662142EEF700FB87A3 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 6B75B0652142EEF700FB87A3 /* .swiftlint.yml */; };
 		6BADDC4421431A1A00661F51 /* R.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BADDC4321431A1A00661F51 /* R.generated.swift */; };
 		6BADDC4621431A5100661F51 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BADDC4521431A5100661F51 /* Coordinator.swift */; };
@@ -79,6 +85,12 @@
 		6B6F5E8221444D230072E180 /* TwitterMoyaRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwitterMoyaRouter.swift; sourceTree = "<group>"; };
 		6B6F5E84214453D80072E180 /* TwitterAccessToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwitterAccessToken.swift; sourceTree = "<group>"; };
 		6B6F5E892144784F0072E180 /* KeychainStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStorageTests.swift; sourceTree = "<group>"; };
+		6B6F5E8B2144811B0072E180 /* TwitterRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwitterRepository.swift; sourceTree = "<group>"; };
+		6B6F5E8D2144812E0072E180 /* APITwitterRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITwitterRepository.swift; sourceTree = "<group>"; };
+		6B6F5E90214484590072E180 /* MockTwitterService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTwitterService.swift; sourceTree = "<group>"; };
+		6B6F5E93214484DC0072E180 /* DataMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataMock.swift; sourceTree = "<group>"; };
+		6B6F5E96214485FA0072E180 /* APITwitterRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITwitterRepositoryTests.swift; sourceTree = "<group>"; };
+		6B6F5E982144866F0072E180 /* MockLocalStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLocalStorage.swift; sourceTree = "<group>"; };
 		6B75B0652142EEF700FB87A3 /* .swiftlint.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = .swiftlint.yml; sourceTree = "<group>"; };
 		6BADDC4321431A1A00661F51 /* R.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = R.generated.swift; sourceTree = "<group>"; };
 		6BADDC4521431A5100661F51 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
@@ -187,6 +199,7 @@
 		6B1B1BC52142EC4700EFEA7F /* mood-reading-machinesTests */ = {
 			isa = PBXGroup;
 			children = (
+				6B6F5E92214484CA0072E180 /* Mocks */,
 				6B6F5E872144783D0072E180 /* Data */,
 				6BADDC8C214324AE00661F51 /* UITests */,
 				6BADDC892143243B00661F51 /* Other */,
@@ -211,6 +224,7 @@
 		6B6F5E872144783D0072E180 /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				6B6F5E95214485DD0072E180 /* Repository */,
 				6B6F5E88214478420072E180 /* Storage */,
 			);
 			path = Data;
@@ -222,6 +236,24 @@
 				6B6F5E892144784F0072E180 /* KeychainStorageTests.swift */,
 			);
 			path = Storage;
+			sourceTree = "<group>";
+		};
+		6B6F5E92214484CA0072E180 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				6B6F5E90214484590072E180 /* MockTwitterService.swift */,
+				6B6F5E93214484DC0072E180 /* DataMock.swift */,
+				6B6F5E982144866F0072E180 /* MockLocalStorage.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
+		6B6F5E95214485DD0072E180 /* Repository */ = {
+			isa = PBXGroup;
+			children = (
+				6B6F5E96214485FA0072E180 /* APITwitterRepositoryTests.swift */,
+			);
+			path = Repository;
 			sourceTree = "<group>";
 		};
 		6BADDC4921431BA200661F51 /* Storage */ = {
@@ -390,6 +422,8 @@
 		6BED69C7214315F500C39777 /* Repositories */ = {
 			isa = PBXGroup;
 			children = (
+				6B6F5E8B2144811B0072E180 /* TwitterRepository.swift */,
+				6B6F5E8D2144812E0072E180 /* APITwitterRepository.swift */,
 			);
 			path = Repositories;
 			sourceTree = "<group>";
@@ -666,11 +700,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6B6F5E8C2144811B0072E180 /* TwitterRepository.swift in Sources */,
 				6BADDC6F214321F800661F51 /* ToastView.swift in Sources */,
 				6BADDC732143224300661F51 /* Constants.swift in Sources */,
 				6BADDC832143239A00661F51 /* Observable+Retry.swift in Sources */,
 				6BADDC9D2143492900661F51 /* Tweet.swift in Sources */,
 				6BADDC4621431A5100661F51 /* Coordinator.swift in Sources */,
+				6B6F5E8E2144812E0072E180 /* APITwitterRepository.swift in Sources */,
 				6B6F5E812144484F0072E180 /* User.swift in Sources */,
 				6BADDC6921431DEB00661F51 /* MainView.swift in Sources */,
 				6BADDC9A2143488F00661F51 /* TwitterMoyaService.swift in Sources */,
@@ -706,12 +742,16 @@
 			buildActionMask = 2147483647;
 			files = (
 				6BADDC86214323FC00661F51 /* BaseUITests+Utils.swift in Sources */,
+				6B6F5E992144866F0072E180 /* MockLocalStorage.swift in Sources */,
 				6BADDC882143242700661F51 /* KIF+Utils.swift in Sources */,
 				6B1B1BC72142EC4700EFEA7F /* mood_reading_machinesTests.swift in Sources */,
 				6BADDC8B2143244B00661F51 /* RetrySpec.swift in Sources */,
+				6B6F5E97214485FA0072E180 /* APITwitterRepositoryTests.swift in Sources */,
 				6B6F5E8A2144784F0072E180 /* KeychainStorageTests.swift in Sources */,
 				6BADDC91214324E300661F51 /* CloudTagViewTests.swift in Sources */,
 				6BADDC8E214324B900661F51 /* BaseUITests.swift in Sources */,
+				6B6F5E91214484590072E180 /* MockTwitterService.swift in Sources */,
+				6B6F5E94214484DC0072E180 /* DataMock.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/mood-reading-machines/Data/Models/TwitterAccessToken.swift
+++ b/mood-reading-machines/Data/Models/TwitterAccessToken.swift
@@ -15,6 +15,10 @@ struct TwitterAccessToken: Codable {
         case accessToken = "access_token"
     }
     
+    init(accessToken: String) {
+        self.accessToken = accessToken
+    }
+    
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.accessToken = try container.decode(String.self, forKey: .accessToken)

--- a/mood-reading-machines/Data/Repositories/APITwitterRepository.swift
+++ b/mood-reading-machines/Data/Repositories/APITwitterRepository.swift
@@ -22,7 +22,7 @@ class APITwitterRepository: TwitterRepository {
     func getUser(_ displayName: String) -> Single<User> {
         return self.ensureAuthentication()
             .flatMap { _ in
-                return self.service.getUsers(displayName)
+                return self.service.getUser(displayName)
         }
     }
     

--- a/mood-reading-machines/Data/Repositories/APITwitterRepository.swift
+++ b/mood-reading-machines/Data/Repositories/APITwitterRepository.swift
@@ -1,0 +1,46 @@
+//
+//  APITwitterRepository.swift
+//  mood-reading-machines
+//
+//  Created by Aline Borges on 08/09/2018.
+//  Copyright © 2018 Aline Borges. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+
+class APITwitterRepository: TwitterRepository {
+    
+    let service: TwitterService
+    let storage: LocalStorage
+    
+    init(service: TwitterService, storage: LocalStorage) {
+        self.service = service
+        self.storage = storage
+    }
+    
+    func getUser(_ displayName: String) -> Single<User> {
+        return self.ensureAuthentication()
+            .flatMap { _ in
+                return self.service.getUsers(displayName)
+        }
+    }
+    
+    func getTweets(_ displayName: String) -> Single<[Tweet]> {
+        return self.ensureAuthentication()
+            .flatMap { _ in
+                return self.service.getTweets(displayName)
+        }
+    }
+    
+    private func ensureAuthentication() -> Single<Void> {
+        if storage.accessToken != nil {
+            return Single.just(())
+        }
+        
+        return service.authenticate()
+            .do(onSuccess: { self.storage.accessToken = $0.accessToken })
+            .map { _ in return () }
+    }
+    
+}

--- a/mood-reading-machines/Data/Repositories/TwitterRepository.swift
+++ b/mood-reading-machines/Data/Repositories/TwitterRepository.swift
@@ -1,16 +1,15 @@
 //
-//  TwitterService.swift
+//  TwitterRepository.swift
 //  mood-reading-machines
 //
-//  Created by Aline Borges on 07/09/2018.
+//  Created by Aline Borges on 08/09/2018.
 //  Copyright © 2018 Aline Borges. All rights reserved.
 //
 
 import Foundation
 import RxSwift
 
-protocol TwitterService {
-    func authenticate() -> Single<TwitterAccessToken>
+protocol TwitterRepository {
     func getUser(_ displayName: String) -> Single<User>
     func getTweets(_ displayName: String) -> Single<[Tweet]>
 }

--- a/mood-reading-machines/Data/Services/TwitterMoyaService.swift
+++ b/mood-reading-machines/Data/Services/TwitterMoyaService.swift
@@ -23,8 +23,8 @@ class TwitterMoyaService: TwitterService {
             .map(TwitterAccessToken.self)
     }
     
-    func searchUsers(_ query: String) -> Single<User> {
-        return self.provider.rx.request(.getUser(displayName: query))
+    func getUser(_ displayName: String) -> Single<User> {
+        return self.provider.rx.request(.getUser(displayName: displayName))
             .map(User.self)
     }
     

--- a/mood-reading-machines/Data/Storage/LocalStorage.swift
+++ b/mood-reading-machines/Data/Storage/LocalStorage.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import RxSwift
 
 protocol LocalStorage: class {
     var accessToken: String? { get set }

--- a/mood-reading-machines/Presentation/Modules/Main/MainView.swift
+++ b/mood-reading-machines/Presentation/Modules/Main/MainView.swift
@@ -56,8 +56,8 @@ extension MainView {
         //TODO: Just testing out, please remove
         self.twitterService.authenticate()
             .map { self.storage.accessToken = $0.accessToken }
-            .flatMap {
-                return self.twitterService.searchUsers("elonmusk")
+            .flatMap { _ in
+                return self.twitterService.getUser("elonmusk")
             }.subscribe(onSuccess: { tweets in
                 print(tweets)
             }).disposed(by: rx.disposeBag)

--- a/mood-reading-machinesTests/Data/Repository/APITwitterRepositoryTests.swift
+++ b/mood-reading-machinesTests/Data/Repository/APITwitterRepositoryTests.swift
@@ -80,6 +80,14 @@ class APITwitterRepositoryTests: XCTestCase {
         
     }
     
-    
+    func test_authentication_shouldBeSaved_afterFirstAuthentication() {
+        
+        self.repository.getTweets("test_user")
+            .subscribe(onSuccess: { _ in }, onError: { _ in })
+            .disposed(by: rx.disposeBag)
+        
+        expect(self.storage.accessToken).toEventually(match("access_token"))
+        
+    }
     
 }

--- a/mood-reading-machinesTests/Data/Repository/APITwitterRepositoryTests.swift
+++ b/mood-reading-machinesTests/Data/Repository/APITwitterRepositoryTests.swift
@@ -1,0 +1,85 @@
+//
+//  APITwitterRepositoryTests.swift
+//  mood-reading-machinesTests
+//
+//  Created by Aline Borges on 08/09/2018.
+//  Copyright © 2018 Aline Borges. All rights reserved.
+//
+
+import Foundation
+import Nimble
+import XCTest
+import RxSwift
+
+@testable import mood_reading_machines
+
+class APITwitterRepositoryTests: XCTestCase {
+    
+    var repository: APITwitterRepository!
+    var service: MockTwitterService!
+    var storage: MockLocalStorage!
+    
+    let disposeBag = DisposeBag()
+    
+    //Before each
+    override func setUp() {
+        self.service = MockTwitterService()
+        self.storage = MockLocalStorage()
+        self.repository = APITwitterRepository(service: service, storage: storage)
+    }
+    
+    //After each
+    override func tearDown() {
+        self.storage.clear()
+        self.service = nil
+        self.storage = nil
+        self.repository = nil
+    }
+    
+    func test_authentication_shouldBeInvoked_whenGettingUserNotAuthenticated() {
+        
+        self.repository.getUser("test_user")
+            .subscribe(onSuccess: { _ in }, onError: { _ in })
+            .disposed(by: rx.disposeBag)
+        
+        expect(self.service.authenticationInvoked).toEventually(beTrue())
+        
+    }
+    
+    func test_authentication_shouldBeInvoked_whenGettingTweetsNotAuthenticated() {
+        
+        self.repository.getTweets("test_user")
+            .subscribe(onSuccess: { _ in }, onError: { _ in })
+            .disposed(by: rx.disposeBag)
+        
+        expect(self.service.authenticationInvoked).toEventually(beTrue())
+        
+    }
+    
+    func test_authentication_shouldNOTbeInvoked_whenGettingUserAlreadyAuthenticated() {
+        
+        self.storage.accessToken = "access_token"
+        
+        self.repository.getUser("test_user")
+            .subscribe(onSuccess: { _ in }, onError: { _ in })
+            .disposed(by: rx.disposeBag)
+        
+        expect(self.service.authenticationInvoked).toNotEventually(beTrue())
+        
+    }
+    
+    func test_authentication_shouldNOTbeInvoked_whenGettingTweetsAlreadyAuthenticated() {
+        
+        self.storage.accessToken = "access_token"
+        
+        self.repository.getTweets("test_user")
+            .subscribe(onSuccess: { _ in }, onError: { _ in })
+            .disposed(by: rx.disposeBag)
+        
+        expect(self.service.authenticationInvoked).toNotEventually(beTrue())
+        
+    }
+    
+    
+    
+}

--- a/mood-reading-machinesTests/Mocks/DataMock.swift
+++ b/mood-reading-machinesTests/Mocks/DataMock.swift
@@ -1,0 +1,22 @@
+//
+//  DataMock.swift
+//  mood-reading-machinesTests
+//
+//  Created by Aline Borges on 08/09/2018.
+//  Copyright © 2018 Aline Borges. All rights reserved.
+//
+
+import Foundation
+@testable import mood_reading_machines
+
+struct DataMock {
+    
+    static let user = User(name: "test",
+                           followersCount: 199,
+                           followingCount: 199,
+                           profileBackgroundColor: "#AAAAAA",
+                           profileBackgroundImageUrl: "http://www.test.com/background.jpg",
+                           profileImageUrl: "http://www.test.com/profile.jpg")
+    
+    static let tweets = [Tweet(text: "Test tweet")]
+}

--- a/mood-reading-machinesTests/Mocks/MockLocalStorage.swift
+++ b/mood-reading-machinesTests/Mocks/MockLocalStorage.swift
@@ -1,0 +1,25 @@
+//
+//  MockLocalStorage.swift
+//  mood-reading-machinesTests
+//
+//  Created by Aline Borges on 08/09/2018.
+//  Copyright © 2018 Aline Borges. All rights reserved.
+//
+
+import Foundation
+
+@testable import mood_reading_machines
+
+class MockLocalStorage: LocalStorage {
+    
+    var accessToken: String?
+    
+    var user: User?
+    
+    func clear() {
+        self.accessToken = nil
+        self.user = nil
+    }
+    
+    
+}

--- a/mood-reading-machinesTests/Mocks/MockTwitterService.swift
+++ b/mood-reading-machinesTests/Mocks/MockTwitterService.swift
@@ -1,0 +1,36 @@
+//
+//  MockService.swift
+//  mood-reading-machinesTests
+//
+//  Created by Aline Borges on 08/09/2018.
+//  Copyright © 2018 Aline Borges. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+
+@testable import mood_reading_machines
+
+class MockTwitterService: TwitterService {
+    
+    let user = DataMock.user
+    let tweets = DataMock.tweets
+    
+    var authenticationInvoked = false
+    
+    var isAuthenticated = false
+    
+    func authenticate() -> Single<TwitterAccessToken> {
+        authenticationInvoked = true
+        return Single.just(TwitterAccessToken(accessToken: "access_token"))
+    }
+    
+    func getUser(_ displayName: String) -> Single<User> {
+        return Single.just(self.user)
+    }
+    
+    func getTweets(_ displayName: String) -> Single<[Tweet]> {
+        return Single.just(self.tweets)
+    }
+    
+}


### PR DESCRIPTION
### :pushpin: References

* **Issue:** closes #32 

### :cyclone: Git merge message

Adds Repository layer to encapsulate Service and authentication calls

### :art: UI changes

None

### :memo: Notes

Services are simple wrappers for Moya layers (if we wanted to replace it for Alamofire, they would be fine)

Repositories actually have logic in them, and can (and SHOULD) be tested. Here I encapsulate the calls to authentication when necessary, and save the tokens after authentication.
